### PR TITLE
feat: 支持跨平台工作台监控与文件化采集日志

### DIFF
--- a/LogSystem/Windows/config/promtail-config.yaml
+++ b/LogSystem/Windows/config/promtail-config.yaml
@@ -24,6 +24,19 @@ scrape_configs:
             mod: mod
             act: act
             msg: msg
+            eventType: eventType
+            sampledAt: sampledAt
+            sampledAtIso: sampledAtIso
+            systemCpuLoad: systemCpuLoad
+            processCpuLoad: processCpuLoad
+            systemMemoryUsage: systemMemoryUsage
+            jvmHeapUsage: jvmHeapUsage
+            networkRxBytesPerSecond: networkRxBytesPerSecond
+            networkTxBytesPerSecond: networkTxBytesPerSecond
+            diskReadBytesPerSecond: diskReadBytesPerSecond
+            diskWriteBytesPerSecond: diskWriteBytesPerSecond
+            cpuAnomaly: cpuAnomaly
+            cpuAnomalyLevel: cpuAnomalyLevel
             chr: chr
             cid: cid
             acc: acc
@@ -41,6 +54,9 @@ scrape_configs:
       - labels:
           mod:
           act:
+          eventType:
+          cpuAnomaly:
+          cpuAnomalyLevel:
           jobName:
           mapName:
       - timestamp:

--- a/gms-server/src/main/java/org/gms/controller/ServerMonitorController.java
+++ b/gms-server/src/main/java/org/gms/controller/ServerMonitorController.java
@@ -25,8 +25,9 @@ public class ServerMonitorController {
     @Tag(name = "/server/" + ApiConstant.LATEST + "/monitor")
     @Operation(summary = "获取服务器监控快照")
     @GetMapping("/" + ApiConstant.LATEST + "/monitor/snapshot")
-    public ResultBody<ServerMonitorSnapshotDTO> getSnapshot() {
-        return ResultBody.success(serverMonitorService.getSnapshot());
+    public ResultBody<ServerMonitorSnapshotDTO> getSnapshot(
+            @RequestParam(value = "interfaceName", required = false) String interfaceName) {
+        return ResultBody.success(serverMonitorService.getSnapshot(interfaceName));
     }
 
     @Tag(name = "/server/" + ApiConstant.LATEST + "/monitor")

--- a/gms-server/src/main/java/org/gms/model/dto/monitor/NetworkInfoDTO.java
+++ b/gms-server/src/main/java/org/gms/model/dto/monitor/NetworkInfoDTO.java
@@ -13,6 +13,8 @@ import java.util.List;
 @AllArgsConstructor
 public class NetworkInfoDTO {
     private String hostName;
+    private String selectedInterfaceName;
+    private String defaultInterfaceName;
     private List<NetworkInterfaceInfoDTO> interfaces;
     private Double rxBytesPerSecond;
     private Double txBytesPerSecond;

--- a/gms-server/src/main/java/org/gms/model/dto/monitor/NetworkInterfaceInfoDTO.java
+++ b/gms-server/src/main/java/org/gms/model/dto/monitor/NetworkInterfaceInfoDTO.java
@@ -17,6 +17,9 @@ public class NetworkInterfaceInfoDTO {
     private Boolean up;
     private Boolean loopback;
     private Boolean virtual;
+    private Boolean internetReachable;
+    private Boolean defaultInterface;
     private Integer mtu;
+    private String primaryAddress;
     private List<String> addresses;
 }

--- a/gms-server/src/main/java/org/gms/service/ServerMonitorService.java
+++ b/gms-server/src/main/java/org/gms/service/ServerMonitorService.java
@@ -26,10 +26,12 @@ import org.gms.model.dto.monitor.ServerMonitorHistoryDTO;
 import org.gms.model.dto.monitor.ServerMonitorHistoryPointDTO;
 import org.gms.model.dto.monitor.ServerMonitorSnapshotDTO;
 import org.gms.net.server.Server;
-import org.gms.server.logging.AuditLogger;
-import org.gms.service.monitor.ContainerRuntimeDetector;
+import org.gms.service.monitor.ContainerInfoCollector;
+import org.gms.service.monitor.ContainerInfoCollectorFactory;
 import org.gms.service.monitor.CpuAnomalyDetector;
-import org.gms.service.monitor.LinuxProcMonitorCollector;
+import org.gms.service.monitor.SystemMetricsCollector;
+import org.gms.service.monitor.SystemMetricsCollectorFactory;
+import org.gms.service.monitor.SystemMetricsSample;
 import org.apache.logging.log4j.message.MapMessage;
 import org.springframework.core.env.Environment;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -65,7 +67,7 @@ import java.util.Objects;
 @Service
 public class ServerMonitorService {
     private static final Logger monitorEventLog = LogManager.getLogger("monitor-event");
-    private static final String DISK_IO_NOTE = "Disk IO rate counters require Linux /proc/diskstats and two samples.";
+    private static final String DISK_IO_NOTE = "Disk IO rate counters are not available on this platform.";
     private static final int DEFAULT_HISTORY_MINUTES = 5;
     private static final int MAX_HISTORY_MINUTES = 7 * 24 * 60;
     private static final int SNAPSHOT_INTERVAL_SECONDS = 10;
@@ -78,8 +80,8 @@ public class ServerMonitorService {
     private final Environment environment;
     private final ObjectMapper objectMapper;
     private final ConfigService configService;
-    private final LinuxProcMonitorCollector procCollector = new LinuxProcMonitorCollector();
-    private final ContainerRuntimeDetector containerRuntimeDetector = new ContainerRuntimeDetector();
+    private final SystemMetricsCollector systemMetricsCollector = SystemMetricsCollectorFactory.create();
+    private final ContainerInfoCollector containerInfoCollector = ContainerInfoCollectorFactory.create();
     private final CpuAnomalyDetector cpuAnomalyDetector = new CpuAnomalyDetector();
     private final HttpClient httpClient = HttpClient.newBuilder()
             .version(HttpClient.Version.HTTP_1_1)
@@ -108,27 +110,27 @@ public class ServerMonitorService {
         long sampledAt = System.currentTimeMillis();
         RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
         List<String> warnings = new ArrayList<>();
-        LinuxProcMonitorCollector.ProcSample procSample = procCollector.collect();
-        warnings.addAll(procSample.getWarnings());
-        ContainerInfoDTO containerInfo = containerRuntimeDetector.detect(warnings);
+        SystemMetricsSample systemSample = systemMetricsCollector.collect();
+        warnings.addAll(systemSample.getWarnings());
+        ContainerInfoDTO containerInfo = containerInfoCollector.detect(warnings);
 
         return ServerMonitorSnapshotDTO.builder()
                 .sample(SampleInfoDTO.builder()
                         .sampledAt(sampledAt)
                         .sampledAtIso(Instant.ofEpochMilli(sampledAt).toString())
-                        .partial(procSample.isPartial() || !warnings.isEmpty())
+                        .partial(systemSample.isPartial() || !warnings.isEmpty())
                         .warnings(warnings)
                         .build())
                 .server(buildServerInfo())
                 .runtime(buildRuntimeInfo(runtimeMXBean))
-                .cpu(buildCpuInfo(procSample))
+                .cpu(buildCpuInfo(systemSample))
                 .jvm(buildJvmInfo())
                 .disks(buildDiskInfo())
-                .diskIo(procSample.getDiskIo() != null ? procSample.getDiskIo() : DiskIoInfoDTO.builder()
+                .diskIo(systemSample.getDiskIo() != null ? systemSample.getDiskIo() : DiskIoInfoDTO.builder()
                         .available(false)
                         .note(DISK_IO_NOTE)
                         .build())
-                .network(buildNetworkInfo(procSample))
+                .network(buildNetworkInfo(systemSample))
                 .container(containerInfo)
                 .build();
     }
@@ -481,6 +483,9 @@ public class ServerMonitorService {
 
     private void emitMonitorEvent(String eventType, ServerMonitorHistoryPointDTO point) {
         MapMessage data = new MapMessage()
+                .with("ts", stringValue(System.currentTimeMillis()))
+                .with("mod", "MONITOR")
+                .with("act", eventType)
                 .with("eventType", eventType)
                 .with("msg", eventType)
                 .with("sampledAt", String.valueOf(point.getSampledAt()))
@@ -507,25 +512,12 @@ public class ServerMonitorService {
         if (point.getCpuAnomalyBaseline() != null) data.with("cpuAnomalyBaseline", stringValue(point.getCpuAnomalyBaseline()));
         String json = writeJson(data.getData());
         if (json != null) {
-            writeMonitorEventLog(eventType, point.getCpuAnomalyLevel(), json);
-        }
-        if ("CPU_ANOMALY".equals(eventType) && "ERROR".equalsIgnoreCase(point.getCpuAnomalyLevel())) {
-            AuditLogger.error("MONITOR", eventType, data, null);
-        } else {
-            AuditLogger.info("MONITOR", eventType, data);
+            writeMonitorEventLog(json);
         }
     }
 
-    private void writeMonitorEventLog(String eventType, String level, String json) {
-        if (!"CPU_ANOMALY".equals(eventType)) {
-            monitorEventLog.info(json);
-            return;
-        }
-        if ("ERROR".equalsIgnoreCase(level)) {
-            monitorEventLog.error(json);
-            return;
-        }
-        monitorEventLog.warn(json);
+    private void writeMonitorEventLog(String json) {
+        monitorEventLog.info(json);
     }
 
     private String stringValue(Object value) {
@@ -594,7 +586,7 @@ public class ServerMonitorService {
                 .build();
     }
 
-    private CpuInfoDTO buildCpuInfo(LinuxProcMonitorCollector.ProcSample procSample) {
+    private CpuInfoDTO buildCpuInfo(SystemMetricsSample systemSample) {
         java.lang.management.OperatingSystemMXBean osBean = ManagementFactory.getOperatingSystemMXBean();
         CpuInfoDTO.CpuInfoDTOBuilder builder = CpuInfoDTO.builder()
                 .osName(System.getProperty("os.name"))
@@ -608,11 +600,11 @@ public class ServerMonitorService {
             builder.processCpuLoad(normalizeLoad(extendedOsBean.getProcessCpuLoad()))
                     .systemCpuLoad(normalizeLoad(extendedOsBean.getCpuLoad()));
         }
-        if (procSample.getSystemCpuLoad() != null) {
-            builder.systemCpuLoad(procSample.getSystemCpuLoad());
+        if (systemSample.getSystemCpuLoad() != null) {
+            builder.systemCpuLoad(systemSample.getSystemCpuLoad());
         }
-        if (procSample.getSystemMemory() != null) {
-            builder.systemMemory(procSample.getSystemMemory());
+        if (systemSample.getSystemMemory() != null) {
+            builder.systemMemory(systemSample.getSystemMemory());
         }
         return builder.build();
     }
@@ -706,12 +698,12 @@ public class ServerMonitorService {
         return disks;
     }
 
-    private NetworkInfoDTO buildNetworkInfo(LinuxProcMonitorCollector.ProcSample procSample) {
+    private NetworkInfoDTO buildNetworkInfo(SystemMetricsSample systemSample) {
         return NetworkInfoDTO.builder()
                 .hostName(resolveHostName())
                 .interfaces(resolveNetworkInterfaces())
-                .rxBytesPerSecond(procSample.getNetworkRxBytesPerSecond())
-                .txBytesPerSecond(procSample.getNetworkTxBytesPerSecond())
+                .rxBytesPerSecond(systemSample.getNetworkRxBytesPerSecond())
+                .txBytesPerSecond(systemSample.getNetworkTxBytesPerSecond())
                 .build();
     }
 

--- a/gms-server/src/main/java/org/gms/service/ServerMonitorService.java
+++ b/gms-server/src/main/java/org/gms/service/ServerMonitorService.java
@@ -43,9 +43,13 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryUsage;
 import java.lang.management.RuntimeMXBean;
 import java.lang.management.ThreadMXBean;
+import java.net.DatagramSocket;
 import java.net.HttpURLConnection;
+import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
+import java.net.Socket;
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
@@ -61,7 +65,9 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
 @Service
@@ -76,6 +82,12 @@ public class ServerMonitorService {
     private static final String CPU_MON_CONFIG_SUB_TYPE = "monitor";
     private static final String CPU_MON_CONFIG_CODE = "cpu_mon";
     private static final String CPU_MON_CONFIG_DESC = "CPU 监控阈值配置";
+    private static final List<InetSocketAddress> INTERNET_PROBES = List.of(
+            new InetSocketAddress("8.8.8.8", 53),
+            new InetSocketAddress("1.1.1.1", 53),
+            new InetSocketAddress("223.5.5.5", 53)
+    );
+    private static final long NETWORK_REACHABLE_CACHE_MS = 60_000L;
 
     private final Environment environment;
     private final ObjectMapper objectMapper;
@@ -88,6 +100,7 @@ public class ServerMonitorService {
             .connectTimeout(Duration.ofSeconds(5))
             .build();
     private final List<ServerMonitorHistoryPointDTO> recentHistory = new ArrayList<>();
+    private final Map<String, ReachabilityCacheEntry> networkReachabilityCache = new ConcurrentHashMap<>();
     private volatile ServerMonitorSnapshotDTO latestSnapshot;
 
     public ServerMonitorService(Environment environment, ObjectMapper objectMapper, ConfigService configService) {
@@ -97,6 +110,13 @@ public class ServerMonitorService {
     }
 
     public ServerMonitorSnapshotDTO getSnapshot() {
+        return getSnapshot(null);
+    }
+
+    public ServerMonitorSnapshotDTO getSnapshot(String networkInterfaceName) {
+        if (networkInterfaceName != null && !networkInterfaceName.isBlank()) {
+            return collectSnapshot(networkInterfaceName);
+        }
         ServerMonitorSnapshotDTO snapshot = latestSnapshot;
         if (snapshot != null) {
             return snapshot;
@@ -107,10 +127,16 @@ public class ServerMonitorService {
     }
 
     public synchronized ServerMonitorSnapshotDTO collectSnapshot() {
+        return collectSnapshot(null);
+    }
+
+    public synchronized ServerMonitorSnapshotDTO collectSnapshot(String networkInterfaceName) {
         long sampledAt = System.currentTimeMillis();
         RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
         List<String> warnings = new ArrayList<>();
-        SystemMetricsSample systemSample = systemMetricsCollector.collect();
+        String defaultInterfaceName = resolveDefaultNetworkInterfaceName();
+        String selectedInterfaceName = firstNonBlank(networkInterfaceName, defaultInterfaceName);
+        SystemMetricsSample systemSample = systemMetricsCollector.collect(selectedInterfaceName);
         warnings.addAll(systemSample.getWarnings());
         ContainerInfoDTO containerInfo = containerInfoCollector.detect(warnings);
 
@@ -130,7 +156,7 @@ public class ServerMonitorService {
                         .available(false)
                         .note(DISK_IO_NOTE)
                         .build())
-                .network(buildNetworkInfo(systemSample))
+                .network(buildNetworkInfo(systemSample, selectedInterfaceName, defaultInterfaceName))
                 .container(containerInfo)
                 .build();
     }
@@ -698,13 +724,51 @@ public class ServerMonitorService {
         return disks;
     }
 
-    private NetworkInfoDTO buildNetworkInfo(SystemMetricsSample systemSample) {
+    private NetworkInfoDTO buildNetworkInfo(SystemMetricsSample systemSample, String selectedInterfaceName, String defaultInterfaceName) {
+        List<NetworkInterfaceInfoDTO> interfaces = resolveNetworkInterfaces(defaultInterfaceName);
+        String resolvedSelectedInterfaceName = resolveSelectedNetworkInterfaceName(interfaces, selectedInterfaceName, defaultInterfaceName);
+        SystemMetricsSample.NetworkRate selectedRate = findNetworkRate(systemSample.getNetworkRates(), resolvedSelectedInterfaceName);
         return NetworkInfoDTO.builder()
                 .hostName(resolveHostName())
-                .interfaces(resolveNetworkInterfaces())
-                .rxBytesPerSecond(systemSample.getNetworkRxBytesPerSecond())
-                .txBytesPerSecond(systemSample.getNetworkTxBytesPerSecond())
+                .selectedInterfaceName(resolvedSelectedInterfaceName)
+                .defaultInterfaceName(defaultInterfaceName)
+                .interfaces(interfaces)
+                .rxBytesPerSecond(selectedRate != null ? selectedRate.getRxBytesPerSecond() : systemSample.getNetworkRxBytesPerSecond())
+                .txBytesPerSecond(selectedRate != null ? selectedRate.getTxBytesPerSecond() : systemSample.getNetworkTxBytesPerSecond())
                 .build();
+    }
+
+    private String resolveSelectedNetworkInterfaceName(List<NetworkInterfaceInfoDTO> interfaces, String requestedInterfaceName, String defaultInterfaceName) {
+        if (interfaces == null || interfaces.isEmpty()) {
+            return null;
+        }
+        if (requestedInterfaceName != null && !requestedInterfaceName.isBlank()
+                && interfaces.stream().anyMatch(item -> Objects.equals(item.getName(), requestedInterfaceName))) {
+            return requestedInterfaceName;
+        }
+        if (defaultInterfaceName != null && interfaces.stream().anyMatch(item -> Objects.equals(item.getName(), defaultInterfaceName))) {
+            return defaultInterfaceName;
+        }
+        return interfaces.stream()
+                .filter(item -> Boolean.TRUE.equals(item.getDefaultInterface()))
+                .map(NetworkInterfaceInfoDTO::getName)
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElseGet(() -> interfaces.stream()
+                        .map(NetworkInterfaceInfoDTO::getName)
+                        .filter(Objects::nonNull)
+                        .findFirst()
+                        .orElse(null));
+    }
+
+    private SystemMetricsSample.NetworkRate findNetworkRate(Map<String, SystemMetricsSample.NetworkRate> rates, String interfaceName) {
+        if (rates == null || rates.isEmpty()) {
+            return null;
+        }
+        if (interfaceName != null) {
+            return rates.get(interfaceName);
+        }
+        return rates.values().iterator().next();
     }
 
     private String resolveHostName() {
@@ -715,7 +779,7 @@ public class ServerMonitorService {
         }
     }
 
-    private List<NetworkInterfaceInfoDTO> resolveNetworkInterfaces() {
+    private List<NetworkInterfaceInfoDTO> resolveNetworkInterfaces(String defaultInterfaceName) {
         List<NetworkInterfaceInfoDTO> result = new ArrayList<>();
         try {
             Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
@@ -724,22 +788,130 @@ public class ServerMonitorService {
             }
             while (interfaces.hasMoreElements()) {
                 NetworkInterface networkInterface = interfaces.nextElement();
+                if (!isInternetCandidate(networkInterface)) {
+                    continue;
+                }
+                List<String> addresses = networkInterface.inetAddresses()
+                        .map(InetAddress::getHostAddress)
+                        .toList();
+                String primaryAddress = addresses.stream().findFirst().orElse(null);
                 result.add(NetworkInterfaceInfoDTO.builder()
                         .name(networkInterface.getName())
                         .displayName(networkInterface.getDisplayName())
                         .up(networkInterface.isUp())
                         .loopback(networkInterface.isLoopback())
                         .virtual(networkInterface.isVirtual())
+                        .internetReachable(true)
+                        .defaultInterface(Objects.equals(networkInterface.getName(), defaultInterfaceName))
                         .mtu(networkInterface.getMTU())
-                        .addresses(networkInterface.inetAddresses()
-                                .map(InetAddress::getHostAddress)
-                                .toList())
+                        .primaryAddress(primaryAddress)
+                        .addresses(addresses)
                         .build());
             }
         } catch (Exception e) {
             return result;
         }
         return result;
+    }
+
+    private boolean isInternetCandidate(NetworkInterface networkInterface) {
+        try {
+            if (!networkInterface.isUp() || networkInterface.isLoopback() || networkInterface.isVirtual()) {
+                return false;
+            }
+            String name = networkInterface.getName();
+            if (name != null) {
+                String lowerName = name.toLowerCase(Locale.ROOT);
+                if (lowerName.equals("lo") || lowerName.startsWith("docker") || lowerName.startsWith("br-")
+                        || lowerName.startsWith("veth") || lowerName.startsWith("virbr")
+                        || lowerName.startsWith("tun") || lowerName.startsWith("tap")) {
+                    return false;
+                }
+            }
+            if (!hasUsableIpv4(networkInterface)) {
+                return false;
+            }
+            return canReachInternet(networkInterface);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private boolean hasUsableIpv4(NetworkInterface networkInterface) {
+        return networkInterface.inetAddresses()
+                .anyMatch(address -> address instanceof Inet4Address
+                        && !address.isAnyLocalAddress()
+                        && !address.isLoopbackAddress()
+                        && !address.isLinkLocalAddress()
+                        && !address.isMulticastAddress());
+    }
+
+    private boolean canReachInternet(NetworkInterface networkInterface) {
+        String cacheKey = networkInterface.getName();
+        long now = System.currentTimeMillis();
+        ReachabilityCacheEntry cached = networkReachabilityCache.get(cacheKey);
+        if (cached != null && now - cached.checkedAtMs() < NETWORK_REACHABLE_CACHE_MS) {
+            return cached.reachable();
+        }
+        boolean reachable = networkInterface.inetAddresses()
+                .filter(address -> address instanceof Inet4Address
+                        && !address.isAnyLocalAddress()
+                        && !address.isLoopbackAddress()
+                        && !address.isLinkLocalAddress()
+                        && !address.isMulticastAddress())
+                .anyMatch(this::canReachInternetFromAddress);
+        networkReachabilityCache.put(cacheKey, new ReachabilityCacheEntry(reachable, now));
+        return reachable;
+    }
+
+    private boolean canReachInternetFromAddress(InetAddress localAddress) {
+        for (InetSocketAddress target : INTERNET_PROBES) {
+            try (Socket socket = new Socket()) {
+                socket.bind(new InetSocketAddress(localAddress, 0));
+                socket.connect(target, 300);
+                return true;
+            } catch (Exception ignored) {
+                // Try next public probe target.
+            }
+        }
+        return false;
+    }
+
+    private String resolveDefaultNetworkInterfaceName() {
+        for (InetSocketAddress target : INTERNET_PROBES) {
+            try (DatagramSocket socket = new DatagramSocket()) {
+                socket.connect(target);
+                InetAddress localAddress = socket.getLocalAddress();
+                if (localAddress == null || localAddress.isAnyLocalAddress()) {
+                    continue;
+                }
+                NetworkInterface networkInterface = NetworkInterface.getByInetAddress(localAddress);
+                if (networkInterface != null && isInternetCandidate(networkInterface)) {
+                    return networkInterface.getName();
+                }
+            } catch (Exception ignored) {
+                // Try next probe target.
+            }
+        }
+        return firstInternetCandidateName();
+    }
+
+    private String firstInternetCandidateName() {
+        try {
+            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+            if (interfaces == null) {
+                return null;
+            }
+            while (interfaces.hasMoreElements()) {
+                NetworkInterface networkInterface = interfaces.nextElement();
+                if (isInternetCandidate(networkInterface)) {
+                    return networkInterface.getName();
+                }
+            }
+        } catch (Exception ignored) {
+            return null;
+        }
+        return null;
     }
 
     private String resolveEnvironment() {
@@ -783,6 +955,8 @@ public class ServerMonitorService {
     private Double normalizeLoad(double value) {
         return value >= 0 ? value : null;
     }
+
+    private record ReachabilityCacheEntry(boolean reachable, long checkedAtMs) {}
 }
 
 

--- a/gms-server/src/main/java/org/gms/service/monitor/ContainerInfoCollector.java
+++ b/gms-server/src/main/java/org/gms/service/monitor/ContainerInfoCollector.java
@@ -1,0 +1,9 @@
+package org.gms.service.monitor;
+
+import org.gms.model.dto.monitor.ContainerInfoDTO;
+
+import java.util.List;
+
+public interface ContainerInfoCollector {
+    ContainerInfoDTO detect(List<String> warnings);
+}

--- a/gms-server/src/main/java/org/gms/service/monitor/ContainerInfoCollectorFactory.java
+++ b/gms-server/src/main/java/org/gms/service/monitor/ContainerInfoCollectorFactory.java
@@ -1,0 +1,19 @@
+package org.gms.service.monitor;
+
+import java.util.Locale;
+
+public final class ContainerInfoCollectorFactory {
+    private ContainerInfoCollectorFactory() {
+    }
+
+    public static ContainerInfoCollector create() {
+        if (isLinux()) {
+            return new ContainerRuntimeDetector();
+        }
+        return new NoopContainerInfoCollector();
+    }
+
+    static boolean isLinux() {
+        return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("linux");
+    }
+}

--- a/gms-server/src/main/java/org/gms/service/monitor/ContainerRuntimeDetector.java
+++ b/gms-server/src/main/java/org/gms/service/monitor/ContainerRuntimeDetector.java
@@ -12,11 +12,12 @@ import java.util.Locale;
 /**
  * Detects Docker/cgroup context and reads cgroup memory usage/limits without shelling out.
  */
-public class ContainerRuntimeDetector {
+public class ContainerRuntimeDetector implements ContainerInfoCollector {
     private static final Path DOCKER_ENV = Path.of("/.dockerenv");
     private static final Path PROC_1_CGROUP = Path.of("/proc/1/cgroup");
     private static final long UNLIMITED_THRESHOLD = Long.MAX_VALUE / 2;
 
+    @Override
     public ContainerInfoDTO detect(List<String> warnings) {
         ContainerInfoDTO.ContainerInfoDTOBuilder builder = ContainerInfoDTO.builder()
                 .runtime("none")

--- a/gms-server/src/main/java/org/gms/service/monitor/JdkSystemMetricsCollector.java
+++ b/gms-server/src/main/java/org/gms/service/monitor/JdkSystemMetricsCollector.java
@@ -1,0 +1,51 @@
+package org.gms.service.monitor;
+
+import com.sun.management.OperatingSystemMXBean;
+import org.gms.model.dto.monitor.DiskIoInfoDTO;
+import org.gms.model.dto.monitor.MemoryInfoDTO;
+
+import java.lang.management.ManagementFactory;
+import java.util.List;
+
+/**
+ * Cross-platform JVM-backed metrics collector used on Windows and other non-Linux systems.
+ */
+public class JdkSystemMetricsCollector implements SystemMetricsCollector {
+    private static final String DISK_IO_UNAVAILABLE_NOTE = "Disk IO rate counters are not available on this platform.";
+
+    @Override
+    public SystemMetricsSample collect() {
+        SystemMetricsSample sample = new SystemMetricsSample();
+        java.lang.management.OperatingSystemMXBean osBean = ManagementFactory.getOperatingSystemMXBean();
+
+        if (osBean instanceof OperatingSystemMXBean extendedOsBean) {
+            sample.setSystemCpuLoad(normalizeLoad(extendedOsBean.getCpuLoad()));
+            sample.setSystemMemory(buildSystemMemory(extendedOsBean));
+        }
+        sample.setDiskIo(DiskIoInfoDTO.builder()
+                .available(false)
+                .note(DISK_IO_UNAVAILABLE_NOTE)
+                .build());
+        sample.setWarnings(List.of());
+        sample.setPartial(false);
+        return sample;
+    }
+
+    private MemoryInfoDTO buildSystemMemory(OperatingSystemMXBean osBean) {
+        long total = osBean.getTotalMemorySize();
+        long free = osBean.getFreeMemorySize();
+        if (total <= 0 || free < 0) {
+            return null;
+        }
+        long used = Math.max(0L, total - free);
+        return MemoryInfoDTO.builder()
+                .used(used)
+                .max(total)
+                .usage((double) used / total)
+                .build();
+    }
+
+    private Double normalizeLoad(double value) {
+        return value >= 0 ? value : null;
+    }
+}

--- a/gms-server/src/main/java/org/gms/service/monitor/LinuxProcMonitorCollector.java
+++ b/gms-server/src/main/java/org/gms/service/monitor/LinuxProcMonitorCollector.java
@@ -15,7 +15,7 @@ import java.util.Map;
  * Lightweight Linux /proc collector. It never throws to callers: unsupported platforms,
  * missing procfs files and parse/read failures are reported as warnings on the sample.
  */
-public class LinuxProcMonitorCollector {
+public class LinuxProcMonitorCollector implements SystemMetricsCollector {
     private static final Path PROC_STAT = Path.of("/proc/stat");
     private static final Path PROC_MEMINFO = Path.of("/proc/meminfo");
     private static final Path PROC_NET_DEV = Path.of("/proc/net/dev");
@@ -24,9 +24,10 @@ public class LinuxProcMonitorCollector {
 
     private ProcCounters previous;
 
-    public synchronized ProcSample collect() {
+    @Override
+    public synchronized SystemMetricsSample collect() {
         List<String> warnings = new ArrayList<>();
-        ProcSample sample = new ProcSample();
+        SystemMetricsSample sample = new SystemMetricsSample();
 
         if (!isLinux()) {
             warnings.add("Linux /proc metrics are unavailable on this operating system.");
@@ -183,7 +184,7 @@ public class LinuxProcMonitorCollector {
         return name.startsWith("loop") || name.startsWith("ram") || name.startsWith("fd");
     }
 
-    private void applyNetworkRates(ProcSample sample, NetCounters current, NetCounters previous, double seconds) {
+    private void applyNetworkRates(SystemMetricsSample sample, NetCounters current, NetCounters previous, double seconds) {
         if (current == null || previous == null) {
             return;
         }
@@ -191,11 +192,11 @@ public class LinuxProcMonitorCollector {
         sample.setNetworkTxBytesPerSecond(rate(current.txBytes, previous.txBytes, seconds));
     }
 
-    private void applyDiskRates(ProcSample sample, DiskCounters current, DiskCounters previous, double seconds) {
+    private void applyDiskRates(SystemMetricsSample sample, DiskCounters current, DiskCounters previous, double seconds) {
         if (current == null || previous == null) {
             sample.setDiskIo(DiskIoInfoDTO.builder()
                     .available(false)
-                    .note("Linux /proc diskstats are unavailable.")
+                    .note("Disk IO rate counters require two samples; rates will be available on the next request.")
                     .build());
             return;
         }
@@ -229,31 +230,6 @@ public class LinuxProcMonitorCollector {
 
     private double clamp01(double value) {
         return Math.max(0D, Math.min(1D, value));
-    }
-
-    public static class ProcSample {
-        private boolean partial;
-        private List<String> warnings = List.of();
-        private Double systemCpuLoad;
-        private MemoryInfoDTO systemMemory;
-        private Double networkRxBytesPerSecond;
-        private Double networkTxBytesPerSecond;
-        private DiskIoInfoDTO diskIo;
-
-        public boolean isPartial() { return partial; }
-        public void setPartial(boolean partial) { this.partial = partial; }
-        public List<String> getWarnings() { return warnings; }
-        public void setWarnings(List<String> warnings) { this.warnings = warnings; }
-        public Double getSystemCpuLoad() { return systemCpuLoad; }
-        public void setSystemCpuLoad(Double systemCpuLoad) { this.systemCpuLoad = systemCpuLoad; }
-        public MemoryInfoDTO getSystemMemory() { return systemMemory; }
-        public void setSystemMemory(MemoryInfoDTO systemMemory) { this.systemMemory = systemMemory; }
-        public Double getNetworkRxBytesPerSecond() { return networkRxBytesPerSecond; }
-        public void setNetworkRxBytesPerSecond(Double networkRxBytesPerSecond) { this.networkRxBytesPerSecond = networkRxBytesPerSecond; }
-        public Double getNetworkTxBytesPerSecond() { return networkTxBytesPerSecond; }
-        public void setNetworkTxBytesPerSecond(Double networkTxBytesPerSecond) { this.networkTxBytesPerSecond = networkTxBytesPerSecond; }
-        public DiskIoInfoDTO getDiskIo() { return diskIo; }
-        public void setDiskIo(DiskIoInfoDTO diskIo) { this.diskIo = diskIo; }
     }
 
     private static class ProcCounters {

--- a/gms-server/src/main/java/org/gms/service/monitor/LinuxProcMonitorCollector.java
+++ b/gms-server/src/main/java/org/gms/service/monitor/LinuxProcMonitorCollector.java
@@ -26,6 +26,11 @@ public class LinuxProcMonitorCollector implements SystemMetricsCollector {
 
     @Override
     public synchronized SystemMetricsSample collect() {
+        return collect(null);
+    }
+
+    @Override
+    public synchronized SystemMetricsSample collect(String networkInterfaceName) {
         List<String> warnings = new ArrayList<>();
         SystemMetricsSample sample = new SystemMetricsSample();
 
@@ -63,7 +68,7 @@ public class LinuxProcMonitorCollector implements SystemMetricsCollector {
                     sample.setSystemCpuLoad(clamp01((double) (totalDelta - idleDelta) / totalDelta));
                 }
             }
-            applyNetworkRates(sample, current.net, previous.net, seconds);
+            applyNetworkRates(sample, current.net, previous.net, seconds, networkInterfaceName);
             applyDiskRates(sample, current.disk, previous.disk, seconds);
         } else {
             warnings.add("Linux /proc rate metrics require two samples; rates will be available on the next request.");
@@ -145,8 +150,10 @@ public class LinuxProcMonitorCollector implements SystemMetricsCollector {
                 }
                 String[] fields = nameAndData[1].trim().split("\\s+");
                 if (fields.length >= 16) {
-                    counters.rxBytes += Long.parseLong(fields[0]);
-                    counters.txBytes += Long.parseLong(fields[8]);
+                    counters.interfaces.put(name, new InterfaceNetCounters(
+                            Long.parseLong(fields[0]),
+                            Long.parseLong(fields[8])
+                    ));
                 }
             }
             return counters;
@@ -184,12 +191,31 @@ public class LinuxProcMonitorCollector implements SystemMetricsCollector {
         return name.startsWith("loop") || name.startsWith("ram") || name.startsWith("fd");
     }
 
-    private void applyNetworkRates(SystemMetricsSample sample, NetCounters current, NetCounters previous, double seconds) {
+    private void applyNetworkRates(SystemMetricsSample sample, NetCounters current, NetCounters previous, double seconds, String networkInterfaceName) {
         if (current == null || previous == null) {
             return;
         }
-        sample.setNetworkRxBytesPerSecond(rate(current.rxBytes, previous.rxBytes, seconds));
-        sample.setNetworkTxBytesPerSecond(rate(current.txBytes, previous.txBytes, seconds));
+        Map<String, SystemMetricsSample.NetworkRate> rates = new HashMap<>();
+        current.interfaces.forEach((name, currentCounters) -> {
+            InterfaceNetCounters previousCounters = previous.interfaces.get(name);
+            if (previousCounters != null) {
+                rates.put(name, new SystemMetricsSample.NetworkRate(
+                        rate(currentCounters.rxBytes, previousCounters.rxBytes, seconds),
+                        rate(currentCounters.txBytes, previousCounters.txBytes, seconds)
+                ));
+            }
+        });
+        sample.setNetworkRates(rates);
+
+        String selectedName = firstNonBlank(networkInterfaceName, rates.keySet().stream().findFirst().orElse(null));
+        SystemMetricsSample.NetworkRate selectedRate = selectedName == null ? null : rates.get(selectedName);
+        if (selectedRate == null && !rates.isEmpty()) {
+            selectedRate = rates.values().iterator().next();
+        }
+        if (selectedRate != null) {
+            sample.setNetworkRxBytesPerSecond(selectedRate.getRxBytesPerSecond());
+            sample.setNetworkTxBytesPerSecond(selectedRate.getTxBytesPerSecond());
+        }
     }
 
     private void applyDiskRates(SystemMetricsSample sample, DiskCounters current, DiskCounters previous, double seconds) {
@@ -215,6 +241,15 @@ public class LinuxProcMonitorCollector implements SystemMetricsCollector {
             return null;
         }
         return delta / seconds;
+    }
+
+    private String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return null;
     }
 
     private long parseLong(String[] parts, int index) {
@@ -246,10 +281,21 @@ public class LinuxProcMonitorCollector implements SystemMetricsCollector {
 
     private record CpuCounters(long total, long idle) {}
 
-    private static class NetCounters {
-        private long rxBytes;
-        private long txBytes;
+    SystemMetricsSample applyNetworkRatesForTest(NetCounters current, NetCounters previous, String networkInterfaceName, double seconds) {
+        SystemMetricsSample sample = new SystemMetricsSample();
+        applyNetworkRates(sample, current, previous, seconds, networkInterfaceName);
+        return sample;
     }
+
+    static class NetCounters {
+        private final Map<String, InterfaceNetCounters> interfaces = new HashMap<>();
+
+        void put(String name, long rxBytes, long txBytes) {
+            interfaces.put(name, new InterfaceNetCounters(rxBytes, txBytes));
+        }
+    }
+
+    private record InterfaceNetCounters(long rxBytes, long txBytes) {}
 
     private static class DiskCounters {
         private long readBytes;

--- a/gms-server/src/main/java/org/gms/service/monitor/NoopContainerInfoCollector.java
+++ b/gms-server/src/main/java/org/gms/service/monitor/NoopContainerInfoCollector.java
@@ -1,0 +1,18 @@
+package org.gms.service.monitor;
+
+import org.gms.model.dto.monitor.ContainerInfoDTO;
+
+import java.util.List;
+
+/**
+ * Non-Linux fallback: no container/cgroup metrics are expected, so no warning is emitted.
+ */
+public class NoopContainerInfoCollector implements ContainerInfoCollector {
+    @Override
+    public ContainerInfoDTO detect(List<String> warnings) {
+        return ContainerInfoDTO.builder()
+                .runtime("none")
+                .detected(false)
+                .build();
+    }
+}

--- a/gms-server/src/main/java/org/gms/service/monitor/SystemMetricsCollector.java
+++ b/gms-server/src/main/java/org/gms/service/monitor/SystemMetricsCollector.java
@@ -2,4 +2,8 @@ package org.gms.service.monitor;
 
 public interface SystemMetricsCollector {
     SystemMetricsSample collect();
+
+    default SystemMetricsSample collect(String networkInterfaceName) {
+        return collect();
+    }
 }

--- a/gms-server/src/main/java/org/gms/service/monitor/SystemMetricsCollector.java
+++ b/gms-server/src/main/java/org/gms/service/monitor/SystemMetricsCollector.java
@@ -1,0 +1,5 @@
+package org.gms.service.monitor;
+
+public interface SystemMetricsCollector {
+    SystemMetricsSample collect();
+}

--- a/gms-server/src/main/java/org/gms/service/monitor/SystemMetricsCollectorFactory.java
+++ b/gms-server/src/main/java/org/gms/service/monitor/SystemMetricsCollectorFactory.java
@@ -1,0 +1,19 @@
+package org.gms.service.monitor;
+
+import java.util.Locale;
+
+public final class SystemMetricsCollectorFactory {
+    private SystemMetricsCollectorFactory() {
+    }
+
+    public static SystemMetricsCollector create() {
+        if (isLinux()) {
+            return new LinuxProcMonitorCollector();
+        }
+        return new JdkSystemMetricsCollector();
+    }
+
+    static boolean isLinux() {
+        return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("linux");
+    }
+}

--- a/gms-server/src/main/java/org/gms/service/monitor/SystemMetricsSample.java
+++ b/gms-server/src/main/java/org/gms/service/monitor/SystemMetricsSample.java
@@ -1,0 +1,31 @@
+package org.gms.service.monitor;
+
+import org.gms.model.dto.monitor.DiskIoInfoDTO;
+import org.gms.model.dto.monitor.MemoryInfoDTO;
+
+import java.util.List;
+
+public class SystemMetricsSample {
+    private boolean partial;
+    private List<String> warnings = List.of();
+    private Double systemCpuLoad;
+    private MemoryInfoDTO systemMemory;
+    private Double networkRxBytesPerSecond;
+    private Double networkTxBytesPerSecond;
+    private DiskIoInfoDTO diskIo;
+
+    public boolean isPartial() { return partial; }
+    public void setPartial(boolean partial) { this.partial = partial; }
+    public List<String> getWarnings() { return warnings; }
+    public void setWarnings(List<String> warnings) { this.warnings = warnings == null ? List.of() : warnings; }
+    public Double getSystemCpuLoad() { return systemCpuLoad; }
+    public void setSystemCpuLoad(Double systemCpuLoad) { this.systemCpuLoad = systemCpuLoad; }
+    public MemoryInfoDTO getSystemMemory() { return systemMemory; }
+    public void setSystemMemory(MemoryInfoDTO systemMemory) { this.systemMemory = systemMemory; }
+    public Double getNetworkRxBytesPerSecond() { return networkRxBytesPerSecond; }
+    public void setNetworkRxBytesPerSecond(Double networkRxBytesPerSecond) { this.networkRxBytesPerSecond = networkRxBytesPerSecond; }
+    public Double getNetworkTxBytesPerSecond() { return networkTxBytesPerSecond; }
+    public void setNetworkTxBytesPerSecond(Double networkTxBytesPerSecond) { this.networkTxBytesPerSecond = networkTxBytesPerSecond; }
+    public DiskIoInfoDTO getDiskIo() { return diskIo; }
+    public void setDiskIo(DiskIoInfoDTO diskIo) { this.diskIo = diskIo; }
+}

--- a/gms-server/src/main/java/org/gms/service/monitor/SystemMetricsSample.java
+++ b/gms-server/src/main/java/org/gms/service/monitor/SystemMetricsSample.java
@@ -4,6 +4,7 @@ import org.gms.model.dto.monitor.DiskIoInfoDTO;
 import org.gms.model.dto.monitor.MemoryInfoDTO;
 
 import java.util.List;
+import java.util.Map;
 
 public class SystemMetricsSample {
     private boolean partial;
@@ -12,6 +13,7 @@ public class SystemMetricsSample {
     private MemoryInfoDTO systemMemory;
     private Double networkRxBytesPerSecond;
     private Double networkTxBytesPerSecond;
+    private Map<String, NetworkRate> networkRates;
     private DiskIoInfoDTO diskIo;
 
     public boolean isPartial() { return partial; }
@@ -26,6 +28,21 @@ public class SystemMetricsSample {
     public void setNetworkRxBytesPerSecond(Double networkRxBytesPerSecond) { this.networkRxBytesPerSecond = networkRxBytesPerSecond; }
     public Double getNetworkTxBytesPerSecond() { return networkTxBytesPerSecond; }
     public void setNetworkTxBytesPerSecond(Double networkTxBytesPerSecond) { this.networkTxBytesPerSecond = networkTxBytesPerSecond; }
+    public Map<String, NetworkRate> getNetworkRates() { return networkRates; }
+    public void setNetworkRates(Map<String, NetworkRate> networkRates) { this.networkRates = networkRates; }
     public DiskIoInfoDTO getDiskIo() { return diskIo; }
     public void setDiskIo(DiskIoInfoDTO diskIo) { this.diskIo = diskIo; }
+
+    public static class NetworkRate {
+        private final Double rxBytesPerSecond;
+        private final Double txBytesPerSecond;
+
+        public NetworkRate(Double rxBytesPerSecond, Double txBytesPerSecond) {
+            this.rxBytesPerSecond = rxBytesPerSecond;
+            this.txBytesPerSecond = txBytesPerSecond;
+        }
+
+        public Double getRxBytesPerSecond() { return rxBytesPerSecond; }
+        public Double getTxBytesPerSecond() { return txBytesPerSecond; }
+    }
 }

--- a/gms-server/src/main/resources/log4j2-spring.xml
+++ b/gms-server/src/main/resources/log4j2-spring.xml
@@ -16,6 +16,14 @@
         <Console name="Console" target="SYSTEM_OUT" follow="true">
             <PatternLayout pattern="${CONSOLE_LOG_PATTERN}"/>
         </Console>
+        <!-- Monitor events: JSON lines intended for Loki/Promtail; file-only to keep periodic samples out of the console. -->
+        <RollingFile name="MonitorEventLog" fileName="logs/audit/monitor.json"
+                     filePattern="logs/audit/monitor-%d{yyyy-MM-dd}.json.gz">
+            <PatternLayout pattern="%m%n"/>
+            <Policies>
+                <TimeBasedTriggeringPolicy />
+            </Policies>
+        </RollingFile>
     </Appenders>
     
     <Loggers>
@@ -25,8 +33,10 @@
         <!-- 关闭 flyway 日志输出 -->
         <Logger name="org.flywaydb" level="ERROR"/>
 
-        <!-- Monitor events: JSON lines intended for Loki/Promtail. Keep additivity=true so Docker/Linux stdout collectors can ingest it before dedicated log-query support lands. -->
-        <Logger name="monitor-event" level="INFO" additivity="true"/>
+        <!-- Monitor events: JSON lines intended for Loki/Promtail; file-only to keep periodic samples out of the console. -->
+        <Logger name="monitor-event" level="INFO" additivity="false">
+            <AppenderRef ref="MonitorEventLog"/>
+        </Logger>
 
         <Root level="INFO">
             <AppenderRef ref="Console"/>

--- a/gms-server/src/main/resources/log4j2.xml
+++ b/gms-server/src/main/resources/log4j2.xml
@@ -61,6 +61,14 @@
                 </Delete>
             </DefaultRolloverStrategy>
         </RollingFile>
+        <!-- 5. Monitor events: JSON lines for Loki/Promtail only; do not attach Console/Root. -->
+        <RollingFile name="MonitorEventLog" fileName="logs/audit/monitor.json"
+                     filePattern="logs/audit/monitor-%d{yyyy-MM-dd}.json.gz">
+            <PatternLayout pattern="%m%n"/>
+            <Policies>
+                <TimeBasedTriggeringPolicy />
+            </Policies>
+        </RollingFile>
     </Appenders>
 
     <Loggers>
@@ -69,6 +77,10 @@
             <AppenderRef ref="AuditLog"/>
             <AppenderRef ref="ErrorLog"/> <!-- 错误同时也写到 ErrorLog -->
             <AppenderRef ref="Console" level="WARN"/>  <!-- 错误同时也输出到控制台，但只显示WARN及以上 -->
+        </Logger>
+
+        <Logger name="monitor-event" level="INFO" additivity="false">
+            <AppenderRef ref="MonitorEventLog"/>
         </Logger>
 
         <!-- 关闭 Druid 日志输出 -->

--- a/gms-server/src/test/java/org/gms/service/monitor/ContainerInfoCollectorFactoryTest.java
+++ b/gms-server/src/test/java/org/gms/service/monitor/ContainerInfoCollectorFactoryTest.java
@@ -1,0 +1,62 @@
+package org.gms.service.monitor;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ContainerInfoCollectorFactoryTest {
+
+    @Test
+    void selectsLinuxCgroupCollectorOnLinux() {
+        withOsName("Linux", () -> assertInstanceOf(ContainerRuntimeDetector.class, ContainerInfoCollectorFactory.create()));
+    }
+
+    @Test
+    void selectsNoopCollectorOnWindows() {
+        withOsName("Windows Server 2022", () -> {
+            ContainerInfoCollector collector = ContainerInfoCollectorFactory.create();
+            var warnings = new ArrayList<String>();
+
+            var container = collector.detect(warnings);
+
+            assertInstanceOf(NoopContainerInfoCollector.class, collector);
+            assertFalse(container.getDetected());
+            assertEquals("none", container.getRuntime());
+            assertTrue(warnings.isEmpty());
+        });
+    }
+
+    @Test
+    void selectsNoopCollectorOnOtherSystems() {
+        withOsName("Mac OS X", () -> {
+            ContainerInfoCollector collector = ContainerInfoCollectorFactory.create();
+            var warnings = new ArrayList<String>();
+
+            var container = collector.detect(warnings);
+
+            assertInstanceOf(NoopContainerInfoCollector.class, collector);
+            assertFalse(container.getDetected());
+            assertEquals("none", container.getRuntime());
+            assertTrue(warnings.isEmpty());
+        });
+    }
+
+    private void withOsName(String osName, Runnable assertion) {
+        String previous = System.getProperty("os.name");
+        try {
+            System.setProperty("os.name", osName);
+            assertion.run();
+        } finally {
+            if (previous == null) {
+                System.clearProperty("os.name");
+            } else {
+                System.setProperty("os.name", previous);
+            }
+        }
+    }
+}

--- a/gms-server/src/test/java/org/gms/service/monitor/JdkSystemMetricsCollectorTest.java
+++ b/gms-server/src/test/java/org/gms/service/monitor/JdkSystemMetricsCollectorTest.java
@@ -1,0 +1,36 @@
+package org.gms.service.monitor;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JdkSystemMetricsCollectorTest {
+
+    @Test
+    void collectsCrossPlatformMetricsWithoutLinuxWarnings() {
+        SystemMetricsSample sample = new JdkSystemMetricsCollector().collect();
+
+        assertFalse(sample.isPartial());
+        assertTrue(sample.getWarnings().stream().noneMatch(warning -> warning.contains("/proc") || warning.contains("cgroup")));
+        if (sample.getSystemCpuLoad() != null) {
+            assertTrue(sample.getSystemCpuLoad() >= 0D && sample.getSystemCpuLoad() <= 1D);
+        }
+        if (sample.getSystemMemory() != null) {
+            assertNotNull(sample.getSystemMemory().getMax());
+            assertTrue(sample.getSystemMemory().getMax() > 0L);
+            assertNotNull(sample.getSystemMemory().getUsed());
+            assertTrue(sample.getSystemMemory().getUsed() >= 0L);
+            assertNotNull(sample.getSystemMemory().getUsage());
+            assertTrue(sample.getSystemMemory().getUsage() >= 0D && sample.getSystemMemory().getUsage() <= 1D);
+        }
+        assertNull(sample.getNetworkRxBytesPerSecond());
+        assertNull(sample.getNetworkTxBytesPerSecond());
+        assertNotNull(sample.getDiskIo());
+        assertFalse(sample.getDiskIo().getAvailable());
+        assertNotNull(sample.getDiskIo().getNote());
+        assertFalse(sample.getDiskIo().getNote().contains("/proc"));
+    }
+}

--- a/gms-server/src/test/java/org/gms/service/monitor/LinuxProcMonitorCollectorTest.java
+++ b/gms-server/src/test/java/org/gms/service/monitor/LinuxProcMonitorCollectorTest.java
@@ -1,0 +1,39 @@
+package org.gms.service.monitor;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LinuxProcMonitorCollectorTest {
+
+    @Test
+    void selectedInterfaceUsesItsOwnNetworkRate() {
+        LinuxProcMonitorCollector collector = new LinuxProcMonitorCollector();
+
+        SystemMetricsSample first = collector.applyNetworkRatesForTest(
+                counters("eth0", 1000L, 500L, "eth1", 4000L, 800L),
+                null,
+                "eth1",
+                1.0D
+        );
+        SystemMetricsSample second = collector.applyNetworkRatesForTest(
+                counters("eth0", 1600L, 900L, "eth1", 7000L, 1800L),
+                counters("eth0", 1000L, 500L, "eth1", 4000L, 800L),
+                "eth1",
+                2.0D
+        );
+
+        assertEquals(null, first.getNetworkRxBytesPerSecond());
+        assertEquals(1500D, second.getNetworkRxBytesPerSecond());
+        assertEquals(500D, second.getNetworkTxBytesPerSecond());
+        assertEquals(300D, second.getNetworkRates().get("eth0").getRxBytesPerSecond());
+    }
+
+    private static LinuxProcMonitorCollector.NetCounters counters(String name1, long rx1, long tx1,
+                                                                  String name2, long rx2, long tx2) {
+        LinuxProcMonitorCollector.NetCounters counters = new LinuxProcMonitorCollector.NetCounters();
+        counters.put(name1, rx1, tx1);
+        counters.put(name2, rx2, tx2);
+        return counters;
+    }
+}

--- a/gms-server/src/test/java/org/gms/service/monitor/SystemMetricsCollectorFactoryTest.java
+++ b/gms-server/src/test/java/org/gms/service/monitor/SystemMetricsCollectorFactoryTest.java
@@ -1,0 +1,37 @@
+package org.gms.service.monitor;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class SystemMetricsCollectorFactoryTest {
+
+    @Test
+    void selectsLinuxProcCollectorOnLinux() {
+        withOsName("Linux", () -> assertInstanceOf(LinuxProcMonitorCollector.class, SystemMetricsCollectorFactory.create()));
+    }
+
+    @Test
+    void selectsJdkCollectorOnWindows() {
+        withOsName("Windows Server 2022", () -> assertInstanceOf(JdkSystemMetricsCollector.class, SystemMetricsCollectorFactory.create()));
+    }
+
+    @Test
+    void selectsJdkCollectorOnOtherSystems() {
+        withOsName("Mac OS X", () -> assertInstanceOf(JdkSystemMetricsCollector.class, SystemMetricsCollectorFactory.create()));
+    }
+
+    private void withOsName(String osName, Runnable assertion) {
+        String previous = System.getProperty("os.name");
+        try {
+            System.setProperty("os.name", osName);
+            assertion.run();
+        } finally {
+            if (previous == null) {
+                System.clearProperty("os.name");
+            } else {
+                System.setProperty("os.name", previous);
+            }
+        }
+    }
+}

--- a/gms-ui/src/api/dashboard.ts
+++ b/gms-ui/src/api/dashboard.ts
@@ -83,10 +83,15 @@ export interface MonitorNetworkInterfaceInfo {
   virtual?: boolean | null;
   mtu?: number | null;
   addresses?: string[] | null;
+  internetReachable?: boolean | null;
+  defaultInterface?: boolean | null;
+  primaryAddress?: string | null;
 }
 
 export interface MonitorNetworkInfo {
   hostName?: string | null;
+  selectedInterfaceName?: string | null;
+  defaultInterfaceName?: string | null;
   interfaces?: MonitorNetworkInterfaceInfo[] | null;
   rxBytesPerSecond?: number | null;
   txBytesPerSecond?: number | null;
@@ -189,8 +194,10 @@ export function shutdown(params?: StopServerParams) {
   return axios.post('/server/v1/shutdown', params);
 }
 
-export function getServerMonitorSnapshot() {
-  return axios.get<ServerMonitorSnapshot>('/server/v1/monitor/snapshot');
+export function getServerMonitorSnapshot(params?: { interfaceName?: string }) {
+  return axios.get<ServerMonitorSnapshot>('/server/v1/monitor/snapshot', {
+    params,
+  });
 }
 
 export interface ServerMonitorHistoryParams {

--- a/gms-ui/src/views/dashboard/workplace/index.vue
+++ b/gms-ui/src/views/dashboard/workplace/index.vue
@@ -161,7 +161,7 @@
         </div>
         <div class="body gms-section-body">
           <div class="resource-grid">
-            <div class="metric-card gms-metric-card">
+            <div class="metric-card gms-metric-card resource-scroll-card">
               <div class="metric-head"
                 ><span>CPU</span
                 ><span class="tag gms-tag info">{{
@@ -198,7 +198,7 @@
                 {{ formatNumber(monitorSnapshot?.cpu?.systemLoadAverage) }}</div
               >
             </div>
-            <div class="metric-card gms-metric-card">
+            <div class="metric-card gms-metric-card resource-scroll-card">
               <div class="metric-head"
                 ><span>{{ $t('workplace.monitor.memory') }}</span
                 ><span class="tag gms-tag info">{{
@@ -231,7 +231,7 @@
                 {{ formatBytes(systemMemoryFree) }}</div
               >
             </div>
-            <div class="metric-card gms-metric-card">
+            <div class="metric-card gms-metric-card resource-scroll-card">
               <div class="metric-head"
                 ><span>{{ $t('workplace.monitor.disk') }}</span
                 ><span class="tag gms-tag gray">{{
@@ -266,7 +266,13 @@
                 ><span
                   >{{ $t('workplace.monitor.network') }} /
                   {{ $t('workplace.monitor.diskIo') }}</span
-                ><span class="tag gms-tag gray">IO</span></div
+                ><a-select
+                  v-model="selectedNetworkInterface"
+                  size="mini"
+                  :options="networkInterfaceOptions"
+                  :disabled="!networkInterfaceOptions.length"
+                  style="width: 168px"
+                /></div
               >
               <div class="io-groups">
                 <div class="io-group">
@@ -854,6 +860,7 @@
   const worldList = ref<ServerWorldInfo[]>([]);
   const channelList = ref<ServerChannelInfo[]>([]);
   const onlinePlayerCount = ref<number | null>(null);
+  const selectedNetworkInterface = ref<string>();
   let monitorTimer: number | undefined;
   let historyTimer: number | undefined;
   const stopConfigVisible = ref(false);
@@ -933,10 +940,23 @@
     if (memory?.used === null || memory?.used === undefined) return undefined;
     return Math.max(memory.max - memory.used, 0);
   });
+  const networkInterfaces = computed(
+    () => monitorSnapshot.value?.network?.interfaces || []
+  );
+  const networkInterfaceOptions = computed(() =>
+    networkInterfaces.value.map((item) => {
+      const name = item.name || item.displayName || '-';
+      const address = item.primaryAddress || item.addresses?.[0];
+      return {
+        label: `${name}${item.defaultInterface ? '（默认）' : ''}${
+          address ? ` · ${address}` : ''
+        }`,
+        value: item.name || '',
+      };
+    }).filter((item) => item.value)
+  );
   const networkInterfacesText = computed(() => {
-    const interfaces = monitorSnapshot.value?.network?.interfaces || [];
-    const names = interfaces
-      .filter((item) => item.up && !item.loopback)
+    const names = networkInterfaces.value
       .map((item) => item.name || item.displayName)
       .filter(Boolean);
     return names.length ? names.join(', ') : '-';
@@ -1245,8 +1265,18 @@
     if (monitorLoading.value) return;
     monitorLoading.value = true;
     try {
-      const { data } = await getServerMonitorSnapshot();
+      const { data } = await getServerMonitorSnapshot({
+        interfaceName: selectedNetworkInterface.value,
+      });
       monitorSnapshot.value = data;
+      const defaultInterfaceName =
+        data?.network?.selectedInterfaceName ||
+        data?.network?.defaultInterfaceName ||
+        data?.network?.interfaces?.find((item) => item.defaultInterface)?.name ||
+        data?.network?.interfaces?.[0]?.name;
+      if (!selectedNetworkInterface.value && defaultInterfaceName) {
+        selectedNetworkInterface.value = defaultInterfaceName;
+      }
       monitorError.value = false;
       if (typeof data?.server?.online === 'boolean')
         serverStatus.value = data.server.online ? 'running' : 'resting';
@@ -1322,6 +1352,11 @@
     }
   };
   watch(trendRange, () => refreshMonitorHistory(true));
+  watch(selectedNetworkInterface, (value, oldValue) => {
+    if (value && oldValue && value !== oldValue) {
+      refreshMonitor(true);
+    }
+  });
 
   const range = (start: number, end: number) => {
     const result = [];
@@ -1802,6 +1837,29 @@
     min-height: 150px;
   }
 
+  .resource-scroll-card {
+    height: 220px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    padding-right: 10px;
+  }
+
+  .resource-scroll-card::-webkit-scrollbar,
+  .hot-scroll::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  .resource-scroll-card::-webkit-scrollbar-thumb,
+  .hot-scroll::-webkit-scrollbar-thumb {
+    border-radius: 999px;
+    background: #d7dde8;
+  }
+
+  .resource-scroll-card::-webkit-scrollbar-track,
+  .hot-scroll::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
   .metric-head {
     display: flex;
     justify-content: space-between;
@@ -2143,6 +2201,12 @@
     .status-bar,
     .resource-grid {
       grid-template-columns: 1fr;
+    }
+
+    .resource-scroll-card {
+      height: auto;
+      max-height: none;
+      overflow-y: visible;
     }
 
     .health-row {


### PR DESCRIPTION
## Summary

- 支持 Windows 与非 Linux 环境使用 JDK 指标采集回退，避免 Linux /proc 与 cgroup 告警污染工作台
- 将工作台监控采集事件写入独立 Loki 文件日志，避免定时采集日志进入控制台
- 补充跨平台采集器选择测试与 Windows Promtail 监控字段配置

## Test Plan

- 后端监控相关单测通过：13 tests, 0 failures
- 后端 Maven package 通过
- Windows 打包 Jar 已下载到 Windows 测试并由用户确认通过
- Docker 测试环境验证 monitor.json 写入、docker logs 无 MONITOR_SNAPSHOT/CPU_ANOMALY 泄漏
- Loki 查询 `{job="gms-audit", mod="MONITOR", act="MONITOR_SNAPSHOT"}` 可返回监控采集事件
- static 构建产物保持未跟踪
